### PR TITLE
Double quote the string when it contain non-alphabet

### DIFF
--- a/lib/tf/hcl/ast.rb
+++ b/lib/tf/hcl/ast.rb
@@ -44,7 +44,7 @@ module Tf
       value :name, ::String
 
       def to_hcl
-        if value[0] =~ /[A-Za-z]/
+        if value[/[A-Za-z_]+/] == value
           value
         else
           "\"#{value}\""


### PR DESCRIPTION
When we construct a HCL object, If the attribute key contains `-` or `:` we should double quote the key name.

This is very common when using AWS with cloudformation, eg:
`aws:cloudformation:stack-name`
`aws:cloudformation:logical-id`

This is a tag name created by AWS.
In Terraform VPC `tags` is a map
https://www.terraform.io/docs/providers/aws/r/vpc.html